### PR TITLE
[WIR] 開発者情報を一覧表示する, Redmineの認証ページリンクを作成する

### DIFF
--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -11,6 +11,7 @@
     <thead>
       <tr>
         <th>名前</th>
+        <th>メールアドレス</th>
         <th></th>
         <th></th>
         <th></th>
@@ -20,6 +21,7 @@
     <tbody>
       <%= content_tag_for(:tr, @developers) do |developer| %>
         <td><%= developer.name %></td>
+        <td><%= developer.adress %></td>
         <td><%= link_to '詳細', developer %></td>
         <td><%= link_to '編集', edit_developer_path(developer) %></td>
         <td><%= link_to '削除', developer, method: :delete, data: { confirm: 'Are you sure?' } %></td>


### PR DESCRIPTION
## ToDo
- [x] US08-F02-SP03: データベース上の開発者情報を一覧表示する #79
- [ ] 'redmine_keys'と'ticket_repositories'まわりを整理する

## How To
'http://0.0.0.0:3000/developers?'にアクセスすると、メールアドレスが確認できる。

## 備考
一民UI（#121）ではない。