### PR TITLE
[IR] Redmine関連情報登録ページへの遷移を実装した

### DIFF
--- a/app/views/base/setting.html.erb
+++ b/app/views/base/setting.html.erb
@@ -1,3 +1,4 @@
 <button type="button" class="btn btn-primary btn-lg setting-button" onclick="jump('/developers')">開発者一覧</button>
 <button type="button" class="btn btn-primary btn-lg setting-button" onclick="jump('/projects')">プロジェクト一覧</button>
 <button type="button" class="btn btn-primary btn-lg setting-button" onclick="jump('/assign_logs')">所属情報作成</button>
+<button type="button" class="btn btn-primary btn-lg setting-button" onclick="jump('/ticket_repositories')">チケット管理情報登録</button>

--- a/app/views/redmine_keys/new.html.erb
+++ b/app/views/redmine_keys/new.html.erb
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <%= link_to redmine_keys_path, class: 'btn btn-default' do %>
+  <%= link_to '/ticket_repositories', class: 'btn btn-default' do %>
     <span class="glyphicon glyphicon-list-alt"></span>
     戻る
   <% end %>

--- a/app/views/ticket_repositories/index.html.erb
+++ b/app/views/ticket_repositories/index.html.erb
@@ -1,1 +1,2 @@
-<h1>Welcome to ticket_repositories toppage</h1>
+<button type="button" class="btn btn-primary btn-lg setting-button" onclick="jump('/ticket_repositories/new')">チケット管理リポジトリの新規登録</button>
+<button type="button" class="btn btn-primary btn-lg setting-button" onclick="jump('/redmine_keys/new')">チケット管理リポジトリ認証情報の登録</button>


### PR DESCRIPTION
## やったこと
「チケット管理ツールリポジトリの登録」と「チケット管理ツールリポジトリの認証情報登録」のページまで辿れるように設定した。

##How To
トップ'http://0.0.0.0:3000/'から
各種管理 → チケット管理情報登録
