### PR TITLE
[IR] redmineAPIで、開発者の実際工数と予定工数を算出する

### DIFF
--- a/app/controllers/portfolio_controller.rb
+++ b/app/controllers/portfolio_controller.rb
@@ -27,16 +27,15 @@ class PortfolioController < ApplicationController
   end
 
   def productivity
-    #***********************************************get ProductionCost
-
+    #*************************************Redmineアカウント情報、tracker情報の取得
     #redmine上のアカウント名
     @developer_name = "SYU"
     #redmine上のアカウントID
     developer_redmineId = nil
 
     #redmine上認証
-    redmineName = "zouyimin"
-    redminePW = "z13299928050"
+    redmineName = ENV['RedmineName']
+    redminePW = ENV['RedminePW']
 
     #redmine上の全てのアカウントを取得し、その中から該当開発者のIDをもらう
     redmine_url = 'http://vibi-redmine.herokuapp.com/projects/vibi'
@@ -58,47 +57,75 @@ class PortfolioController < ApplicationController
 
     # トラッカーHash
     @productivity_info = Hash.new
+    @productivity_info[:tracker] = []
 
-    # トラッカー名
-    @productivity_info[:tracker] = ['BUG', 'FEATURE', 'SUPPORT', 'DOCUMENT']
-    gon.tracker = @productivity_info[:tracker]
+    # トラッカー名の取得
+    tracker_req = RestClient::Request.execute method: :get, url: 'http://vibi-redmine.herokuapp.com/trackers.json', user: redmineName, password: redminePW
+    tracker_json = JSON.parse(tracker_req)
 
-    #実績工数Hash
-    estimated_hours = Hash.new
-    #実績工数Hash初期化
-    @productivity_info[:tracker].each do |tracker|
-      estimated_hours[tracker] = 0
+    tracker_json['trackers'].each do |tracker|
+      @productivity_info[:tracker].push(tracker['name'])
     end
 
+    gon.tracker = @productivity_info[:tracker]
+
+    #予定工数Hash
+    estimated_hours = Hash.new
+    #実績工数Hash
+    result_hours = Hash.new
+
+    #実績工数情報の取得
+    result_req = RestClient::Request.execute method: :get, url: redmine_url+'/time_entries.json', user: redmineName, password: redminePW
+    result_json = JSON.parse(result_req)
+
+    #工数Hash初期化
+    @productivity_info[:tracker].each do |tracker|
+      estimated_hours[tracker] = 0
+      result_hours[tracker] = 0
+    end
+
+    #*************************************************工数計算部分
     #予定工数の計算
     issues_json['issues'].each do |issue|
-      @productivity_info[:tracker].each do |tracker|
-        if issue['tracker']['name'] == tracker then
-          estimated_hours[tracker] = estimated_hours[tracker] + issue['estimated_hours']
+
+      #予定工数計算部分
+      if nil != issue['estimated_hours'] then
+        estimated_hours[issue['tracker']['name']] = estimated_hours[issue['tracker']['name']] + issue['estimated_hours']
+      end
+
+      #実績工数計算部分
+      result_json['time_entries'].each do |time_entry|
+        if issue['id'] == time_entry['issue']['id'] then
+          result_hours[issue['tracker']['name']] = result_hours[issue['tracker']['name']] + time_entry['hours']
         end
       end
 
     end
 
-    #実績工数Array
+    #予定工数Arrayの設定
     estimated_hours_result = []
     estimated_hours.each{|key, value|
       estimated_hours_result.push(value)
     }
-    puts estimated_hours_result
+    #実績工数Arrayの設定
+    result_hours_result = []
+    result_hours.each{|key, value|
+      result_hours_result.push(value)
+    }
 
+    puts result_hours_result
 
-    #******************************************************graph
+    #****************************************************graph
 
     # 実績工数
-    @productivity_info[:result] = [120, 56, 79, 12]
+    @productivity_info[:result] = result_hours_result
     gon.task_result = @productivity_info[:result]
 
     # 予定工数
-    @productivity_info[:estimate] = [100, 70, 70, 10]
+    @productivity_info[:estimate] = estimated_hours_result
     gon.task_estimate = @productivity_info[:estimate]
 
     # 開発者名
-    @productivity_info[:developer] = '玄葉 条士郎'
+    @productivity_info[:developer] = @developer_name
   end
 end

--- a/app/controllers/portfolio_controller.rb
+++ b/app/controllers/portfolio_controller.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 class PortfolioController < ApplicationController
   def index
   end
@@ -51,7 +49,7 @@ class PortfolioController < ApplicationController
     end
 
     #redmine上の該当開発者の全てのissue情報を取得する
-    issues_req = RestClient::Request.execute method: :get, url: redmine_url+'/issues.json?status_id=*&assigned_to_id='+ developer_redmineId.to_s, user: redmineName, password: redminePW
+    issues_req = RestClient::Request.execute method: :get, url: redmine_url+'/issues.json?status_id=*&limit=100&assigned_to_id='+ developer_redmineId.to_s, user: redmineName, password: redminePW
 
     issues_json = JSON.parse(issues_req)
 
@@ -75,7 +73,7 @@ class PortfolioController < ApplicationController
     result_hours = Hash.new
 
     #実績工数情報の取得
-    result_req = RestClient::Request.execute method: :get, url: redmine_url+'/time_entries.json', user: redmineName, password: redminePW
+    result_req = RestClient::Request.execute method: :get, url: redmine_url+'/time_entries.json?limit=100', user: redmineName, password: redminePW
     result_json = JSON.parse(result_req)
 
     #工数Hash初期化

--- a/app/controllers/portfolio_controller.rb
+++ b/app/controllers/portfolio_controller.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class PortfolioController < ApplicationController
   def index
   end
@@ -25,6 +27,37 @@ class PortfolioController < ApplicationController
   end
 
   def productivity
+    #**************************************************get issue Time
+
+    #redmine上のアカウント名
+    @developer_name = "SYU"
+    #redmine上のアカウントID
+    developer_redmineId = nil
+
+    #redmine上認証
+    redmineName = "zouyimin"
+    redminePW = "z13299928050"
+
+    #redmine上の全てのアカウントを取得し、その中から該当開発者のIDをもらう
+    memberships_url = 'http://vibi-redmine.herokuapp.com/projects/vibi'
+    memberships_req = RestClient::Request.execute method: :get, url: memberships_url+'/memberships.json', user: redmineName, password: redminePW
+
+    # perse
+    memberships_json = JSON.parse(memberships_req)
+
+    memberships_json['memberships'].each do |membership|
+      if membership['user']['name'] == @developer_name then
+        developer_redmineId = membership['user']['id']
+      end
+    end
+
+    #redmine上の該当開発者の全てのissue情報を取得する
+    issues_req = RestClient::Request.execute method: :get, url: memberships_url+'/issues.json?status_id=*&assigned_to_id='+ developer_redmineId.to_s, user: redmineName, password: redminePW
+
+    issues_json = JSON.parse(issues_req)
+
+    #puts issues_json
+    #******************************************************graph
     @productivity_info = Hash.new
 
     # トラッカー名


### PR DESCRIPTION
### Done
- [x] redmineAPIで開発者が所有しているissueの取得
- [x] 取得しているissueの中から予定工数の算出
- [x] 実際工数から該当開発者の実際工数の算出
- [x] グラフ化にする(screen shotの時、ブラウザを縮小したので、画面がおかしいけど、実際は問題ない)
![image](https://cloud.githubusercontent.com/assets/7775369/10190222/1397ecb4-67a6-11e5-87bd-379cc7f7c19a.png)

- [x] pagination問題の解決
       - [x] 一回redmineAPIに問合せすると最大限100個情報しか取れない。issuesが100以上の場合、一回だけ問合せですべての情報が取れない。解決するため、最初回アクセスして、取ったデータが不完全の場合、またアクセスし、最後までデータを取る機能を実装する
       - [x] time_entriesも同上

### Redmine Pagination URL
```
http://www.redmine.org/projects/redmine/wiki/Rest_api#Collection-resources-and-pagination
```
![image](https://cloud.githubusercontent.com/assets/7775369/10190140/92107e72-67a5-11e5-80bd-93baec6f9a3e.png)
### Review
- zouyimin/production-costに移動
- portfolio_controller.rbのproductivityの中に
![image](https://cloud.githubusercontent.com/assets/7775369/10194141/1ac90f9c-67c2-11e5-89ea-90f4fbdc8239.png)

  自分のRedmineのアカウント名とPWを書く
  (例えば：RedmineName = "name"  RedminePW = "pw")

- 以下のところ見たい開発者のRedmine上のアカウント名を書く
![image](https://cloud.githubusercontent.com/assets/7775369/10194243/98460b82-67c2-11e5-86dc-0c9b639e149f.png)
  (鄒:SYU 大木:OKI 柳沼:YAGINUMA 孫:SUN)
  - 私以外の人は自分が担当したRedmineチケットは予定工数が入れなかったので、多分グラフ中の「予定工数」が全部0hになる

- http://localhost:3000//portfolio/productivity

- paginationをReviewしたい場合
  - issueのpagination
![image](https://cloud.githubusercontent.com/assets/7775369/10194377/47ba1900-67c3-11e5-9e9e-3f416b22165d.png)
     の中の赤線部分を同時に100~10の数字に変更(二箇所値必ず一致)
  - time entryのpagination
![image](https://cloud.githubusercontent.com/assets/7775369/10194441/a615f118-67c3-11e5-9f09-a2f5a698519c.png)
     の中の赤線部分を同時に100~10の数字に変更(二箇所値必ず一致)
- 変更してからまたhttp://localhost:3000//portfolio/productivity にアクセス