### PR TITLE
[IR] commitsグラフを非同期処理の変更

### DIFF
--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -1,137 +1,126 @@
-//画面初期化した時実行するfunction
+var create_commit_graph = function(all_commit,own_commit,developer_name){
+    alert(all_commit + developer_name + own_commit);
+    var commit_count = [all_commit, own_commit];
+    var developer_name = ['その他', developer_name];
+    var color = ['#b1d7e8', '#006ab3'];
 
-$(document).ready(function(){
-    $.ajax({
-        url: "commits_ajax",
-        type: "POST",
-        dataType: "json",
-        async: false,
-        data: "",
-        success: function(commit_data) {
-            alert("success" + commit_data.name);
-        }
-    });
-});
+    var topPadding = 50;
+    var leftPadding = 100;
+    var rightPadding = 20;
+    var w = 500+leftPadding+rightPadding;
+    var h = 400;
 
-var commit_count = [gon.all_commit, gon.own_commit];
-var developer_name = ['その他', gon.developer_name];
-var color = ['#b1d7e8', '#006ab3'];
+    var barHeight = 100;
 
-var topPadding = 50;
-var leftPadding = 100;
-var rightPadding = 20;
-var w = 500+leftPadding+rightPadding;
-var h = 400;
+    var xScale = d3.scale.linear()
+        .domain([0, gon.all_commit])
+        .range([0, 500])
+        .nice();
 
-var barHeight = 100;
+    var xAxis = d3.svg.axis()
+        .scale(xScale)
+        .orient("bottom");
 
-var xScale = d3.scale.linear()
-               .domain([0, gon.all_commit])
-               .range([0, 500])
-               .nice();
-
-var xAxis = d3.svg.axis()
-                  .scale(xScale)
-                  .orient("bottom");
-
-var svg = d3.select("body")
-            .append("svg")
-            .attr("width", w)
-            .attr("height", h);
+    var svg = d3.select("body")
+        .append("svg")
+        .attr("width", w)
+        .attr("height", h);
 
 // x軸の表示
-svg.append("g")
-   .attr({
-     class: "axis",
-     transform: "translate("+leftPadding+", 150)"
-   })
-   .call(xAxis);
+    svg.append("g")
+        .attr({
+            class: "axis",
+            transform: "translate("+leftPadding+", 150)"
+        })
+        .call(xAxis);
 
 // 棒グラフの描画
-svg.selectAll("rect")
-   .data(commit_count)
-   .enter()
-   .append("rect")
-   .attr("fill", function(d, i) {
-     return color[i];
-   })
-   .transition()
-   .duration(2000)
-   .each("start", function() {
-     d3.select(this).attr({
-       width: 0
-     })
-   })
-   .attr("x", leftPadding)
-   .attr("y", 40)
-   .attr("width", function(d) {
-     return xScale(d);
-   })
-   .attr("height", barHeight);
+    svg.selectAll("rect")
+        .data(commit_count)
+        .enter()
+        .append("rect")
+        .attr("fill", function(d, i) {
+            return color[i];
+        })
+        .transition()
+        .duration(2000)
+        .each("start", function() {
+            d3.select(this).attr({
+                width: 0
+            })
+        })
+        .attr("x", leftPadding)
+        .attr("y", 40)
+        .attr("width", function(d) {
+            return xScale(d);
+        })
+        .attr("height", barHeight);
 
 // コミット数の表示
-svg.selectAll("commit_count")
-   .data(commit_count)
-   .enter()
-   .append("text")
-   .attr("opacity", 0.0)
-   .text(function(d, i) {
-     if (i == 0) {
-       return d - commit_count[i+1];
-     } else {
-       return d;
-     }
-   })
-   .attr("x", function(d, i) {
-     if (i == 0) {
-       return leftPadding + xScale(commit_count[i+1]) + xScale(d - commit_count[i+1])/2;
-     } else {
-       return leftPadding + xScale(d)/2;
-     }
-   })
-   .attr("y", function(d) {
-     return 30 + barHeight/2;
-   })
-   .attr("text-anchor", "middle")
-   .attr("font-family", "sans-serif")
-   .attr("font-size", "20px")
-   .attr("fill", "white")
-   .transition()
-   .each("end", function() {
-     d3.select(this)
-       .transition()
-       .duration(2000)
-       .attr("opacity", 1.0)
-   });
+    svg.selectAll("commit_count")
+        .data(commit_count)
+        .enter()
+        .append("text")
+        .attr("opacity", 0.0)
+        .text(function(d, i) {
+            if (i == 0) {
+                return d - commit_count[i+1];
+            } else {
+                return d;
+            }
+        })
+        .attr("x", function(d, i) {
+            if (i == 0) {
+                return leftPadding + xScale(commit_count[i+1]) + xScale(d - commit_count[i+1])/2;
+            } else {
+                return leftPadding + xScale(d)/2;
+            }
+        })
+        .attr("y", function(d) {
+            return 30 + barHeight/2;
+        })
+        .attr("text-anchor", "middle")
+        .attr("font-family", "sans-serif")
+        .attr("font-size", "20px")
+        .attr("fill", "white")
+        .transition()
+        .each("end", function() {
+            d3.select(this)
+                .transition()
+                .duration(2000)
+                .attr("opacity", 1.0)
+        });
 
 // 開発者名の表示
-svg.selectAll("developer_name")
-   .data(developer_name)
-   .enter()
-   .append("text")
-   .attr("opacity", 0.0)
-   .text(function(d, i) {
-     return d;
-   })
-   .attr("x", function(d, i) {
-     if (i == 0) {
-       return leftPadding + xScale(commit_count[i+1]) + xScale(commit_count[i] - commit_count[i+1])/2;
-     } else {
-       return leftPadding + xScale(commit_count[i])/2;
-     }
-   })
-   .attr("y", function(d) {
-     return 30;
-   })
-   .attr("text-anchor", "middle")
-   .attr("font-family", "sans-serif")
-   .attr("font-size", "15px")
-   .attr("fill", "black")
-   .transition()
-   .each("end", function() {
-     d3.select(this)
-       .transition()
-       .duration(2000)
-       .attr("opacity", 1.0)
-   });
+    svg.selectAll("developer_name")
+        .data(developer_name)
+        .enter()
+        .append("text")
+        .attr("opacity", 0.0)
+        .text(function(d, i) {
+            return d;
+        })
+        .attr("x", function(d, i) {
+            if (i == 0) {
+                return leftPadding + xScale(commit_count[i+1]) + xScale(commit_count[i] - commit_count[i+1])/2;
+            } else {
+                return leftPadding + xScale(commit_count[i])/2;
+            }
+        })
+        .attr("y", function(d) {
+            return 30;
+        })
+        .attr("text-anchor", "middle")
+        .attr("font-family", "sans-serif")
+        .attr("font-size", "15px")
+        .attr("fill", "black")
+        .transition()
+        .each("end", function() {
+            d3.select(this)
+                .transition()
+                .duration(2000)
+                .attr("opacity", 1.0)
+        });
+}
+
 

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -1,5 +1,5 @@
 var create_commit_graph = function(all_commit,own_commit,developer_name){
-    alert(all_commit + developer_name + own_commit);
+    //alert(all_commit + developer_name + own_commit);
     var commit_count = [all_commit, own_commit];
     var developer_name = ['その他', developer_name];
     var color = ['#b1d7e8', '#006ab3'];
@@ -13,7 +13,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     var barHeight = 100;
 
     var xScale = d3.scale.linear()
-        .domain([0, gon.all_commit])
+        .domain([0, all_commit])
         .range([0, 500])
         .nice();
 

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -1,3 +1,18 @@
+//画面初期化した時実行するfunction
+
+$(document).ready(function(){
+    $.ajax({
+        url: "commits_ajax",
+        type: "POST",
+        dataType: "json",
+        async: false,
+        data: "",
+        success: function(commit_data) {
+            alert("success" + commit_data.name);
+        }
+    });
+});
+
 var commit_count = [gon.all_commit, gon.own_commit];
 var developer_name = ['その他', gon.developer_name];
 var color = ['#b1d7e8', '#006ab3'];
@@ -52,7 +67,7 @@ svg.selectAll("rect")
    .attr("width", function(d) {
      return xScale(d);
    })
-   .attr("height", barHeight); 
+   .attr("height", barHeight);
 
 // コミット数の表示
 svg.selectAll("commit_count")

--- a/app/assets/javascripts/own/commit_graph_ajax.js
+++ b/app/assets/javascripts/own/commit_graph_ajax.js
@@ -9,6 +9,7 @@ var commitAjax = function() {
     }
   })
   .done(function(commit_data) {
+          $('#detail').html("開発者の人数は合計" + commit_data.total_developers + "人です。<br>コミット率は" + commit_data.commit_rate +"%です。");
           create_commit_graph(commit_data.all_commit,commit_data.own_commit,commit_data.developer_name);
   });
 }

--- a/app/assets/javascripts/own/commit_graph_ajax.js
+++ b/app/assets/javascripts/own/commit_graph_ajax.js
@@ -1,0 +1,15 @@
+var commitAjax = function() {
+  $.ajax({
+    type: 'post',
+    url: 'commits_ajax',
+    dataType: "json",
+    data: "",
+    success: function(commit_data) {
+        //alert("success" + commit_data.developer_name);
+    }
+  })
+  .done(function(commit_data) {
+          create_commit_graph(commit_data.all_commit,commit_data.own_commit,commit_data.developer_name);
+  });
+}
+

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -26,6 +26,9 @@ Vibi.load = function(e) {
   if(gon.controller === 'portfolio'){
     $('.flexslider').flexslider();
   }
+  if(gon.controller === 'commit_counter'){
+      commitAjax();
+  }
 };
 
 //Windowの読込が完了したらVibi.loadを実行する

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -26,6 +26,11 @@ Vibi.load = function(e) {
   if(gon.controller === 'portfolio'){
     $('.flexslider').flexslider();
   }
+
+  if(gon.controller === "commit") {
+          showCommitsGraph();
+  }
+
 };
 
 //Windowの読込が完了したらVibi.loadを実行する

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -26,11 +26,6 @@ Vibi.load = function(e) {
   if(gon.controller === 'portfolio'){
     $('.flexslider').flexslider();
   }
-
-  if(gon.controller === "commit") {
-          showCommitsGraph();
-  }
-
 };
 
 //Windowの読込が完了したらVibi.loadを実行する

--- a/app/controllers/commit_counter_controller.rb
+++ b/app/controllers/commit_counter_controller.rb
@@ -19,55 +19,56 @@ class CommitCounterController < ApplicationController
 
   def commits_ajax
 
-    #repo設定
-    @version_repo_id = 1
-    repo_url = VersionRepository.find(@version_repo_id)[:url]
-    githubRepo = repo_url.gsub(/https:\/\/github.com\//,'')
-
-    #チーム内開発者のコミット情報を取る
-    Octokit.auto_paginate = true
-    contributors = Octokit.contribs(githubRepo)
-
-    #対象開発者の名前
-    developer_name = "Altairzym"
-
-    #全員のコミット数
-    total_commits = 0
-
-    #対象開発者のコミット数
-    developer_commits = 0
-
-    #チーム内開発者総数
-    total_developers = contributors.length
-
-    contributors.each do |contributor|
-      total_commits = total_commits + contributor['contributions']
-      if contributor['login'] == developer_name then
-        developer_commits = contributor['contributions']
-      end
-    end
-
-    #コミット率
-    @commits_rate = (developer_commits.to_f/total_commits.to_f * 100).round(3)
-
-    @commit_info = Hash.new
-
-    # The number of commits
-    # Sample data
-    @commit_info[:own_commit] = developer_commits
-    @commit_info[:all_commit] = total_commits
-    gon.own_commit = @commit_info[:own_commit]
-    gon.all_commit = @commit_info[:all_commit]
-
-    # Developer name
-    # Sample data
-    @commit_info[:developer_name] = developer_name
-    gon.developer_name = @commit_info[:developer_name]
-
-    # Developer num
-    # SampleData
-    @commit_info[:developer_num] = total_developers
-    gon.developer_num = @commit_info[:developer_num]
+    # #repo設定
+    # @version_repo_id = 1
+    # repo_url = VersionRepository.find(@version_repo_id)[:url]
+    # githubRepo = repo_url.gsub(/https:\/\/github.com\//,'')
+    #
+    # #チーム内開発者のコミット情報を取る
+    # Octokit.auto_paginate = true
+    # contributors = Octokit.contribs(githubRepo)
+    #
+    # #対象開発者の名前
+    # developer_name = "Altairzym"
+    #
+    # #全員のコミット数
+    # total_commits = 0
+    #
+    # #対象開発者のコミット数
+    # developer_commits = 0
+    #
+    # #チーム内開発者総数
+    # total_developers = contributors.length
+    #
+    # contributors.each do |contributor|
+    #   total_commits = total_commits + contributor['contributions']
+    #   if contributor['login'] == developer_name then
+    #     developer_commits = contributor['contributions']
+    #   end
+    # end
+    #
+    # #コミット率
+    # @commits_rate = (developer_commits.to_f/total_commits.to_f * 100).round(3)
+    #
+    # @commit_info = Hash.new
+    #
+    # # The number of commits
+    # # Sample data
+    # @commit_info[:own_commit] = developer_commits
+    # @commit_info[:all_commit] = total_commits
+    # gon.own_commit = @commit_info[:own_commit]
+    # gon.all_commit = @commit_info[:all_commit]
+    #
+    # # Developer name
+    # # Sample data
+    # @commit_info[:developer_name] = developer_name
+    # gon.developer_name = @commit_info[:developer_name]
+    #
+    # # Developer num
+    # # SampleData
+    # @commit_info[:developer_num] = total_developers
+    # gon.developer_num = @commit_info[:developer_num]
+    render :json => {'name' => 'Yamada', 'old' => 28}
   end
 
 end

--- a/app/controllers/commit_counter_controller.rb
+++ b/app/controllers/commit_counter_controller.rb
@@ -1,6 +1,23 @@
 class CommitCounterController < ApplicationController
   def index
-    #コミット数の集計処理をここに記載
+    #repo設定
+    @version_repo_id = 1
+    repo_url = VersionRepository.find(@version_repo_id)[:url]
+    githubRepo = repo_url.gsub(/https:\/\/github.com\//,'')
+
+    #チーム内開発者のコミット情報を取る
+    Octokit.auto_paginate = true
+    contributors = Octokit.contribs(githubRepo)
+
+    #対象開発者の名前
+    @developer_name = "Altairzym"
+
+    #チーム内開発者総数
+    @total_developers = contributors.length
+
+  end
+
+  def commits_ajax
 
     #repo設定
     @version_repo_id = 1
@@ -51,7 +68,6 @@ class CommitCounterController < ApplicationController
     # SampleData
     @commit_info[:developer_num] = total_developers
     gon.developer_num = @commit_info[:developer_num]
-
   end
 
 end

--- a/app/controllers/commit_counter_controller.rb
+++ b/app/controllers/commit_counter_controller.rb
@@ -19,56 +19,58 @@ class CommitCounterController < ApplicationController
 
   def commits_ajax
 
-    # #repo設定
-    # @version_repo_id = 1
-    # repo_url = VersionRepository.find(@version_repo_id)[:url]
-    # githubRepo = repo_url.gsub(/https:\/\/github.com\//,'')
-    #
-    # #チーム内開発者のコミット情報を取る
-    # Octokit.auto_paginate = true
-    # contributors = Octokit.contribs(githubRepo)
-    #
-    # #対象開発者の名前
-    # developer_name = "Altairzym"
-    #
-    # #全員のコミット数
-    # total_commits = 0
-    #
-    # #対象開発者のコミット数
-    # developer_commits = 0
-    #
-    # #チーム内開発者総数
-    # total_developers = contributors.length
-    #
-    # contributors.each do |contributor|
-    #   total_commits = total_commits + contributor['contributions']
-    #   if contributor['login'] == developer_name then
-    #     developer_commits = contributor['contributions']
-    #   end
-    # end
-    #
-    # #コミット率
-    # @commits_rate = (developer_commits.to_f/total_commits.to_f * 100).round(3)
-    #
-    # @commit_info = Hash.new
-    #
-    # # The number of commits
-    # # Sample data
-    # @commit_info[:own_commit] = developer_commits
-    # @commit_info[:all_commit] = total_commits
+    #repo設定
+    @version_repo_id = 1
+    repo_url = VersionRepository.find(@version_repo_id)[:url]
+    githubRepo = repo_url.gsub(/https:\/\/github.com\//,'')
+
+    #チーム内開発者のコミット情報を取る
+    Octokit.auto_paginate = true
+    contributors = Octokit.contribs(githubRepo)
+
+    #対象開発者の名前
+    developer_name = "Altairzym"
+
+    #全員のコミット数
+    total_commits = 0
+
+    #対象開発者のコミット数
+    developer_commits = 0
+
+    #チーム内開発者総数
+    total_developers = contributors.length
+
+    contributors.each do |contributor|
+      total_commits = total_commits + contributor['contributions']
+      if contributor['login'] == developer_name then
+        developer_commits = contributor['contributions']
+      end
+    end
+
+    #コミット率
+    @commits_rate = (developer_commits.to_f/total_commits.to_f * 100).round(3)
+
+    @commit_info = Hash.new
+
+    # The number of commits
+    # Sample data
+    @commit_info[:own_commit] = developer_commits
+    @commit_info[:all_commit] = total_commits
     # gon.own_commit = @commit_info[:own_commit]
     # gon.all_commit = @commit_info[:all_commit]
-    #
-    # # Developer name
-    # # Sample data
+
+    # Developer name
+    # Sample data
     # @commit_info[:developer_name] = developer_name
     # gon.developer_name = @commit_info[:developer_name]
-    #
-    # # Developer num
-    # # SampleData
+
+    # Developer num
+    # SampleData
     # @commit_info[:developer_num] = total_developers
     # gon.developer_num = @commit_info[:developer_num]
-    render :json => {'name' => 'Yamada', 'old' => 28}
+    finalStr = "{\"all_commit\":" + total_commits.to_s + ",\"own_commit\":" + developer_commits.to_s + ",\"developer_name\":\"" + developer_name + "\"}"
+    graphJson = JSON.parse(finalStr)
+    render :json => graphJson
   end
 
 end

--- a/app/controllers/commit_counter_controller.rb
+++ b/app/controllers/commit_counter_controller.rb
@@ -1,20 +1,7 @@
 class CommitCounterController < ApplicationController
   def index
-    #repo設定
-    @version_repo_id = 1
-    repo_url = VersionRepository.find(@version_repo_id)[:url]
-    githubRepo = repo_url.gsub(/https:\/\/github.com\//,'')
-
-    #チーム内開発者のコミット情報を取る
-    Octokit.auto_paginate = true
-    contributors = Octokit.contribs(githubRepo)
-
     #対象開発者の名前
     @developer_name = "Altairzym"
-
-    #チーム内開発者総数
-    @total_developers = contributors.length
-
   end
 
   def commits_ajax
@@ -48,7 +35,7 @@ class CommitCounterController < ApplicationController
     end
 
     #コミット率
-    @commits_rate = (developer_commits.to_f/total_commits.to_f * 100).round(3)
+    commits_rate = (developer_commits.to_f/total_commits.to_f * 100).round(3)
 
     @commit_info = Hash.new
 
@@ -68,7 +55,7 @@ class CommitCounterController < ApplicationController
     # SampleData
     # @commit_info[:developer_num] = total_developers
     # gon.developer_num = @commit_info[:developer_num]
-    finalStr = "{\"all_commit\":" + total_commits.to_s + ",\"own_commit\":" + developer_commits.to_s + ",\"developer_name\":\"" + developer_name + "\"}"
+    finalStr = "{\"all_commit\":" + total_commits.to_s + ",\"own_commit\":" + developer_commits.to_s + ",\"developer_name\":\"" + developer_name + "\",\"commit_rate\":" + commits_rate.to_s + ",\"total_developers\":" + total_developers.to_s + "}"
     graphJson = JSON.parse(finalStr)
     render :json => graphJson
   end

--- a/app/controllers/commit_counter_controller.rb
+++ b/app/controllers/commit_counter_controller.rb
@@ -39,22 +39,6 @@ class CommitCounterController < ApplicationController
 
     @commit_info = Hash.new
 
-    # The number of commits
-    # Sample data
-    @commit_info[:own_commit] = developer_commits
-    @commit_info[:all_commit] = total_commits
-    # gon.own_commit = @commit_info[:own_commit]
-    # gon.all_commit = @commit_info[:all_commit]
-
-    # Developer name
-    # Sample data
-    # @commit_info[:developer_name] = developer_name
-    # gon.developer_name = @commit_info[:developer_name]
-
-    # Developer num
-    # SampleData
-    # @commit_info[:developer_num] = total_developers
-    # gon.developer_num = @commit_info[:developer_num]
     finalStr = "{\"all_commit\":" + total_commits.to_s + ",\"own_commit\":" + developer_commits.to_s + ",\"developer_name\":\"" + developer_name + "\",\"commit_rate\":" + commits_rate.to_s + ",\"total_developers\":" + total_developers.to_s + "}"
     graphJson = JSON.parse(finalStr)
     render :json => graphJson

--- a/app/views/commit_counter/index.html.erb
+++ b/app/views/commit_counter/index.html.erb
@@ -1,7 +1,6 @@
 <h1><%= @developer_name %>さんのコミット数</h1>
-<p>
-開発者の人数は合計<%= @total_developers %>人です。<br>
-  コミット率は%です。
+<p id="detail">
+
 </p>
 
 <%= include_gon %>

--- a/app/views/commit_counter/index.html.erb
+++ b/app/views/commit_counter/index.html.erb
@@ -1,7 +1,7 @@
-<h1><%= @commit_info[:developer_name] %>さんのコミット数</h1>
+<h1><%= @developer_name %>さんのコミット数</h1>
 <p>
-開発者の人数は合計<%= @commit_info[:developer_num] %>人です。<br>
-  コミット率は<%= @commits_rate %>%です。
+開発者の人数は合計<%= @total_developers %>人です。<br>
+  コミット率は%です。
 </p>
 
 <%= include_gon %>

--- a/app/views/commit_counter/index.html.erb
+++ b/app/views/commit_counter/index.html.erb
@@ -6,3 +6,4 @@
 
 <%= include_gon %>
 <%= javascript_include_tag "commit_counter_graph" %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get 'datasamples/index'
   get 'comments_counter/index'
   get 'commit_counter/index'
+  post 'commit_counter/commits_ajax'
 
   get 'projects/select_developer'
   post 'projects/select_developer'


### PR DESCRIPTION
### Done
- [x] controllerの中に、画面遷移部分とajax呼び出す用部分の分離
- [x] ownファイルの下に、ajax用ファイル「commit_graph_ajax.js」の作成
- [x] 非同期処理の修正と画面の表示

### 結論
- まず画面を遷移する、遷移してからまたデータの取得処理を行い、描画するような感じに修正した
- 修正する前の画面と同じ、実装方式だけ変更した

### Review
- zouyimin/commits-ajaxに移動
- #168 の「レビュー流れ」中の**「zouyimin/commits-counterと言うブランチに移動」以外の内容**を参照する
- 後はブラウザで　http://localhost:3000/commit_counter/index