### PR TITLE
[IR] コメント数グラフの非同期仕様の変更

### DIFF
--- a/app/assets/javascripts/comments_counter_graph.js
+++ b/app/assets/javascripts/comments_counter_graph.js
@@ -1,91 +1,92 @@
-var width = 960,
-    height = 350
+var create_comment_graph = function(nodes,links){
+    var width = 960,
+        height = 350
 
-var svg = d3.select("body").append("svg")
-    .attr("width", width)
-    .attr("height", height);
+    var svg = d3.select("body").append("svg")
+        .attr("width", width)
+        .attr("height", height);
 
-var force = d3.layout.force()
-    .gravity(.05)
-    .distance(200)
-    .charge(-100)
-    .size([width, height]);
+    var force = d3.layout.force()
+        .gravity(.05)
+        .distance(200)
+        .charge(-100)
+        .size([width, height]);
 
-var graph = gon.graph
+    force
+        .nodes(nodes)
+        .links(links)
+        .start();
 
-force
-    .nodes(graph.nodes)
-    .links(graph.links)
-    .start();
-
-var marker = svg.append("defs").append("marker")
-    .attr({
-        'id': "arrowhead",
-        'refX': 13,
-        'refY': 2,
-        'markerWidth': 4,
-        'markerHeight': 4,
-        'orient': "auto"
-    });
-
-marker.append("path")
-    .attr({
-        d: "M 0,0 V 4 L4,2 Z",
-        fill: "#ccc"
-    });
-
-var link = svg.selectAll(".link")
-    .data(graph.links)
-    .enter().append("g")
-    .attr("class", "link")
-    .append("line")
-    .attr("class", "link-line")
-    .attr("marker-end","url(#arrowhead)")
-    .style("stroke-width", function(d) { return Math.sqrt(d.value); });
-
-var linkText = svg.selectAll(".link")
-    .append("text")
-    .attr("class", "link-label")
-    .attr("font-family", "Arial, Helvetica, sans-serif")
-    .attr("fill", "Black")
-    .style("font", "normal 12px Arial")
-    .attr("dy", ".35em")
-    .attr("text-anchor", "middle")
-    .text(function(d) {
-        return d.value;
-    });
-
-var node = svg.selectAll(".node")
-    .data(graph.nodes)
-    .enter().append("g")
-    .attr("class", "node")
-    .call(force.drag);
-
-node.append("image")
-    .attr("xlink:href", "https://github.com/favicon.ico")
-    .attr("x", -8)
-    .attr("y", -8)
-    .attr("width", 40)
-    .attr("height", 40);
-
-node.append("text")
-    .attr("dx", 35)
-    .attr("dy", ".35em")
-    .text(function(d) { return d.name });
-
-force.on("tick", function() {
-    link.attr("x1", function(d) { return d.source.x; })
-        .attr("y1", function(d) { return d.source.y; })
-        .attr("x2", function(d) { return d.target.x; })
-        .attr("y2", function(d) { return d.target.y; });
-
-    linkText
-        .attr("x", function(d) {
-            return ((d.source.x + d.target.x)/2);
-        })
-        .attr("y", function(d) {
-            return ((d.source.y + d.target.y)/2);
+    var marker = svg.append("defs").append("marker")
+        .attr({
+            'id': "arrowhead",
+            'refX': 13,
+            'refY': 2,
+            'markerWidth': 4,
+            'markerHeight': 4,
+            'orient': "auto"
         });
 
-    node.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
-});
+    marker.append("path")
+        .attr({
+            d: "M 0,0 V 4 L4,2 Z",
+            fill: "#ccc"
+        });
+
+    var link = svg.selectAll(".link")
+        .data(links)
+        .enter().append("g")
+        .attr("class", "link")
+        .append("line")
+        .attr("class", "link-line")
+        .attr("marker-end","url(#arrowhead)")
+        .style("stroke-width", function(d) { return Math.sqrt(d.value); });
+
+    var linkText = svg.selectAll(".link")
+        .append("text")
+        .attr("class", "link-label")
+        .attr("font-family", "Arial, Helvetica, sans-serif")
+        .attr("fill", "Black")
+        .style("font", "normal 12px Arial")
+        .attr("dy", ".35em")
+        .attr("text-anchor", "middle")
+        .text(function(d) {
+            return d.value;
+        });
+
+    var node = svg.selectAll(".node")
+        .data(nodes)
+        .enter().append("g")
+        .attr("class", "node")
+        .call(force.drag);
+
+    node.append("image")
+        .attr("xlink:href", "https://github.com/favicon.ico")
+        .attr("x", -8)
+        .attr("y", -8)
+        .attr("width", 40)
+        .attr("height", 40);
+
+    node.append("text")
+        .attr("dx", 35)
+        .attr("dy", ".35em")
+        .text(function(d) { return d.name });
+
+    force.on("tick", function() {
+        link.attr("x1", function(d) { return d.source.x; })
+            .attr("y1", function(d) { return d.source.y; })
+            .attr("x2", function(d) { return d.target.x; })
+            .attr("y2", function(d) { return d.target.y; });
+
+        linkText
+            .attr("x", function(d) {
+                return ((d.source.x + d.target.x)/2);
+            })
+            .attr("y", function(d) {
+                return ((d.source.y + d.target.y)/2);
+            });
+
+        node.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
+    });
+}
+

--- a/app/assets/javascripts/own/comment_graph_ajax.js
+++ b/app/assets/javascripts/own/comment_graph_ajax.js
@@ -1,0 +1,15 @@
+var commentAjax = function() {
+  $.ajax({
+    type: 'post',
+    url: 'comments_ajax',
+    dataType: "json",
+    data: "",
+    success: function(comment_data) {
+        //alert("success" + comment_data.nodes);
+    }
+  })
+  .done(function(comment_data) {
+          create_comment_graph(comment_data.nodes,comment_data.links);
+  });
+}
+

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -33,6 +33,9 @@ Vibi.load = function(e) {
   if(gon.controller === 'commit_counter'){
       commitAjax();
   }
+  if(gon.controller === 'comments_counter'){
+      commentAjax();
+  }
 
 };
 

--- a/app/controllers/comments_counter_controller.rb
+++ b/app/controllers/comments_counter_controller.rb
@@ -2,7 +2,12 @@ require 'json'
 
 class CommentsCounterController < ApplicationController
   def index
-#issuesの状態
+    #見たい開発者のGithub上のUserName
+    @assigneeArg = "Altairzym"
+  end
+
+  def comments_ajax
+    #issuesの状態
     stateArg = "all"
 
     #見たい開発者のGithub上のUserName
@@ -43,7 +48,7 @@ class CommentsCounterController < ApplicationController
     issues = Octokit.list_issues(githubRepo,state: stateArg)
 
     #最終json
-    @graph = ""
+    finalStr = ""
     nodes = ""
     links = ""
 
@@ -91,8 +96,10 @@ class CommentsCounterController < ApplicationController
       end
     }
 
-    @graph = JSON.parse(nodes + links)
-    gon.graph = @graph
+    finalStr = nodes + links
+
+    render :json => finalStr
+
   end
 
 end

--- a/app/views/comments_counter/index.html.erb
+++ b/app/views/comments_counter/index.html.erb
@@ -3,7 +3,6 @@
   <p>線上の数字は、<%= @assigneeArg %>の各開発者に対するコメント数です。</p>
 </div>
 
-<%= include_gon %>
 <%= javascript_include_tag "comments_counter_graph" %>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   get 'datasamples/index'
   get 'comments_counter/index'
+  post 'comments_counter/comments_ajax'
   get 'commit_counter/index'
   post 'commit_counter/commits_ajax'
 


### PR DESCRIPTION
### Done
- [x] controllerの中に、画面遷移部分とajax呼び出す用部分の分離
- [x] ownファイルの下に、ajax用ファイル「comment_graph_ajax.js」の作成
- [x] 非同期処理の修正と画面の表示

### 結論
- まず画面を遷移する、遷移してからまたデータの取得処理を行い、描画するような感じに修正した
- 修正する前の画面と同じ、実装方式だけ変更した

### Review
- comments_controller.rbの中に

![image](https://cloud.githubusercontent.com/assets/7775369/10556962/7f175a32-74d1-11e5-8c85-5c2f4964773f.png)

の部分名前を変更して、githubのユーザ名とパスワードを書く
- http://localhost:3000/comments_counter/index にアクセス