### PR TITLE
[IR] #231 Viewの実装

### DIFF
--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -85,6 +85,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
           'opacity': 1
         });
 
+
       var line = d3.svg.line()
                    .x(function(d) {
                      return d[0];
@@ -142,29 +143,71 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
             return bar_max_height-yScale(d);
           }
         });
-        /*
+
+      // 各コミット数の表示
+      svg.select('.chart_area')
+        .selectAll('.bar_figure')
+        .data(commit_count)
+        .enter()
+        .append('text')
+        .attr('class', 'bar_figure')
+        .text(function(d) {
+          return d;
+        })
+        .attr({
+          'x': function(d, i) {
+            return bar_start_x+i*60+20;
+          },
+          'y': function(d, i) {
+            return bar_max_height-yScale(d)-15;
+          },
+          'font-family': 'sans-serif',
+          'font-size': '15px',
+          'text-anchor': 'middle',
+          'dominant-baseline': 'middle',
+          'fill': '#777777',
+          'opacity': 0
+        })
+        .transition()
+        .delay(2*event_time)
+        .duration(event_time)
+        .attr({
+          'opacity': 1
+        });
+
+      // 開発者名の表示
+      svg.select('.chart_area')
+        .selectAll('.developer_name')
+        .data(developers)
+        .enter()
+        .append('text')
+        .attr('class', 'developer_name')
+        .text(function(d) {
+          return d;
+        })
+        .attr({
+          'x': function(d, i) {
+            return bar_start_x+i*60+20;
+          },
+          'y': function(d, i) {
+            return bar_max_height+10;
+          },
+          'font-family': 'sans-serif',
+          'font-size': '15px',
+          'text-anchor': 'start',
+          'dominant-baseline': 'middle',
+          'writing-mode': 'tb',
+          'fill': '#777777',
+          'opacity': 0
+        })
         .transition()
         .delay(event_time)
         .duration(event_time)
-        .each('start', function() {
-          svg.select('.chart_area')
-            .selectAll('.bar')
-            .data(commit_count)
-            .attr({
-              'width': 40,
-              'height': 100,
-              'x': function(d, i) {
-                return i*60;
-              },
-              'y': 100,
-              'fill': 'blue',
-              'opacity': 0
-            })
-        })
         .attr({
           'opacity': 1
-        }); */
+        });
 
+      
       // y軸の表示
       svg.select('.chart_area')
          .append('path')

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -3,123 +3,36 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     var developer_name = ['その他', developer_name];
     var color = ['#b1d7e8', '#006ab3'];
 
-    var topPadding = 50;
-    var leftPadding = 100;
-    var rightPadding = 20;
-    var w = 500+leftPadding+rightPadding;
-    var h = 400;
+    // 取得データの一覧
+    // developers: 開発者のリスト
+    // commit_count: 各開発者のコミット数
 
-    var barHeight = 100;
+    // 取得データサンプル(連携後に消去)
+    var developers = ['DeveloperA', 'DeveloperB', 'DeveloperC', 'DeveloperD', '玄葉      条士郎'];
+    var commit_count = [38, 56, 103, 11, 82];
 
-    var xScale = d3.scale.linear()
-        .domain([0, all_commit])
-        .range([0, 500])
-        .nice();
+    // グラフの色
+    var base_color = '#4f81bd';
+    var faint_color = '#749ccb';
 
-    var xAxis = d3.svg.axis()
-        .scale(xScale)
-        .orient("bottom");
+    // SVG領域の設定
+    var width = 960;
+    var height = 640;
+    var margin = {top: 0, right: 100, bottom: 0, left: 100};
 
+    // SVG領域の描画
     var svg = d3.select("body")
-        .append("svg")
-        .attr("width", w)
-        .attr("height", h);
+          .append("svg")
+          .attr("class", "commit_counter_graph")
+          .attr("width", width)
+          .attr("height", height);
 
-// x軸の表示
-    svg.append("g")
-        .attr({
-            class: "axis",
-            transform: "translate("+leftPadding+", 150)"
-        })
-        .call(xAxis);
-
-// 棒グラフの描画
-    svg.selectAll("rect")
-        .data(commit_count)
-        .enter()
-        .append("rect")
-        .attr("fill", function(d, i) {
-            return color[i];
-        })
-        .transition()
-        .duration(2000)
-        .each("start", function() {
-            d3.select(this).attr({
-                width: 0
-            })
-        })
-        .attr("x", leftPadding)
-        .attr("y", 40)
-        .attr("width", function(d) {
-            return xScale(d);
-        })
-        .attr("height", barHeight);
-
-// コミット数の表示
-    svg.selectAll("commit_count")
-        .data(commit_count)
-        .enter()
-        .append("text")
-        .attr("opacity", 0.0)
-        .text(function(d, i) {
-            if (i == 0) {
-                return d - commit_count[i+1];
-            } else {
-                return d;
-            }
-        })
-        .attr("x", function(d, i) {
-            if (i == 0) {
-                return leftPadding + xScale(commit_count[i+1]) + xScale(d - commit_count[i+1])/2;
-            } else {
-                return leftPadding + xScale(d)/2;
-            }
-        })
-        .attr("y", function(d) {
-            return 30 + barHeight/2;
-        })
-        .attr("text-anchor", "middle")
-        .attr("font-family", "sans-serif")
-        .attr("font-size", "20px")
-        .attr("fill", "white")
-        .transition()
-        .each("end", function() {
-            d3.select(this)
-                .transition()
-                .duration(2000)
-                .attr("opacity", 1.0)
-        });
-
-// 開発者名の表示
-    svg.selectAll("developer_name")
-        .data(developer_name)
-        .enter()
-        .append("text")
-        .attr("opacity", 0.0)
-        .text(function(d, i) {
-            return d;
-        })
-        .attr("x", function(d, i) {
-            if (i == 0) {
-                return leftPadding + xScale(commit_count[i+1]) + xScale(commit_count[i] - commit_count[i+1])/2;
-            } else {
-                return leftPadding + xScale(commit_count[i])/2;
-            }
-        })
-        .attr("y", function(d) {
-            return 30;
-        })
-        .attr("text-anchor", "middle")
-        .attr("font-family", "sans-serif")
-        .attr("font-size", "15px")
-        .attr("fill", "black")
-        .transition()
-        .each("end", function() {
-            d3.select(this)
-                .transition()
-                .duration(2000)
-                .attr("opacity", 1.0)
-        });
+    // SVG領域の確認
+    svg.append("text")
+      .text("Hello World")
+      .attr({
+        x: 150,
+        y: 150
+      })
+      .attr("font-size", "50px");
 }
-
-

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -9,7 +9,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
 
     // 取得データサンプル(連携後に消去)
     var developers = ['DeveloperA', 'DeveloperB', 'DeveloperC', 'DeveloperD', '玄葉      条士郎'];
-    var commit_count = [38, 56, 103, 11, 82];
+    var commit_count = [38, 55, 103, 11, 82];
 
     // グラフの色
     var base_color = '#4f81bd';
@@ -38,6 +38,12 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     /* 棒グラフの描画 */
     /******************/
     function drawBarChart() {
+      // イベントの所要時間
+      var event_time = 800;
+
+      // 棒の描画エリア
+      var bar_start_x = 100;
+
       // 棒の最大の高さ
       var bar_max_height = 300;
 
@@ -54,43 +60,53 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
                      .range([0, bar_max_height])
                      .nice();
      
-     var line = d3.svg.line()
-                  .x(function(d) {
-                    return d[0];
-                  })
-                  .y(function(d) {
-                    return d[1];
-                  });
-
+      // グラフタイトルの表示
       svg.select('.chart_area')
-        .append('path')
+        .append('text')
         .transition()
-        .duration(1000)
+        .duration(event_time)
         .each('start', function() {
           d3.select(this)
             .attr({
-              'class': 'yaxis',
-              'd': line([[100,bar_max_height], [100, 0]]),
-              'stroke': '#aaaaaa',
-              'stroke-width': 1,
+              'class': 'chart_title',
+              'x': bar_start_x-50,
+              'y': bar_max_height/2,
+              'font-family': 'sans-serif',
+              'font-size': '20px',
+              'text-anchor': 'middle',
+              'dominant-baseline': 'middle',
+              'writing-mode': 'tb',
+              'fill': '#777777',
               'opacity': 0
-            });
+            })
+            .text('コミット数');
         })
         .attr({
           'opacity': 1
         });
 
+      var line = d3.svg.line()
+                   .x(function(d) {
+                     return d[0];
+                   })
+                   .y(function(d) {
+                     return d[1];
+                   });
+
+
+      // 平均軸の表示
       svg.select('.chart_area')
         .append('path')
         .transition()
-        .duration(1000)
+        .duration(event_time)
         .each('start', function() {
           d3.select(this)
             .attr({
               'class': 'xaxis',
-              'd': line([[100,bar_max_height], [100+developers.length*60, bar_max_height]]),
+              'd': line([[bar_start_x-20, bar_max_height-yScale(getCommitAvarage())], [bar_start_x-20+developers.length*60, bar_max_height-yScale(getCommitAvarage())]]),
               'stroke': '#aaaaaa',
               'stroke-width': 1,
+              'stroke-dasharray': 10,
               'opacity': 0
             });
         })
@@ -98,5 +114,110 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
           'opacity': 1
         });
 
+      // 棒の表示 
+      svg.select('.chart_area')
+        .selectAll('.bar')
+        .data(commit_count)
+        .enter()
+        .append('rect')
+        .attr('class', '.bar')
+        .attr({
+          'width': 40,
+          'height': 0,
+          'x': function(d, i) {
+            return bar_start_x+i*60;
+          },
+          'y': bar_max_height,
+          'fill': base_color,
+          'opacity': 1
+        })
+        .transition()
+        .duration(event_time)
+        .delay(event_time)
+        .attr({
+          'height': function(d, i) {
+            return yScale(d);
+          },
+          'y': function(d, i) {
+            return bar_max_height-yScale(d);
+          }
+        });
+        /*
+        .transition()
+        .delay(event_time)
+        .duration(event_time)
+        .each('start', function() {
+          svg.select('.chart_area')
+            .selectAll('.bar')
+            .data(commit_count)
+            .attr({
+              'width': 40,
+              'height': 100,
+              'x': function(d, i) {
+                return i*60;
+              },
+              'y': 100,
+              'fill': 'blue',
+              'opacity': 0
+            })
+        })
+        .attr({
+          'opacity': 1
+        }); */
+
+      // y軸の表示
+      svg.select('.chart_area')
+         .append('path')
+         .transition()
+         .duration(event_time)
+         .each('start', function() {
+           d3.select(this)
+             .attr({
+               'class': 'yaxis',
+               'd': line([[bar_start_x-20, bar_max_height], [bar_start_x-20, 0]]),
+               'stroke': '#aaaaaa',
+               'stroke-width': 1,
+               'opacity': 0
+             });
+         })
+         .attr({
+           'opacity': 1
+         });
+
+       // x軸の表示
+       svg.select('.chart_area')
+         .append('path')
+         .transition()
+         .duration(event_time)
+         .each('start', function() {
+           d3.select(this)
+             .attr({
+               'class': 'xaxis',
+               'd': line([[bar_start_x-20, bar_max_height], [bar_start_x-20+developers.length*60, bar_max_height]]),
+               'stroke': '#aaaaaa',
+               'stroke-width': 1,
+               'opacity': 0
+             });
+         })
+         .attr({
+           'opacity': 1
+         });
     };
+
+    /*************/
+    /* Utilities */
+    /*************/
+    
+    // コミット数の平均値
+    function getCommitAvarage() {
+      var avg = 0;
+
+      for (var i=0; i<commit_count.length; i++) {
+        avg += commit_count[i];
+      }
+
+      avg = avg/commit_count.length;
+      return avg.toFixed(1);
+    }
+    
 };

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -121,7 +121,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
         .data(commit_count)
         .enter()
         .append('rect')
-        .attr('class', '.bar')
+        .attr('class', 'bar')
         .attr({
           'width': 40,
           'height': 0,
@@ -177,11 +177,11 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
 
       // 開発者名の表示
       svg.select('.chart_area')
-        .selectAll('.developer_name')
+        .selectAll('.developer_label')
         .data(developers)
         .enter()
         .append('text')
-        .attr('class', 'developer_name')
+        .attr('class', 'developer_label')
         .text(function(d) {
           return d;
         })
@@ -389,6 +389,84 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
             .select('.sort')
             .select('.sort_name')
             .text(order[in_order]);
+
+          /* 開発者の登録順 */
+          if (in_order == 0) {
+            // 開発者ラベルのソート
+            svg.select('.chart_area')
+              .selectAll('.developer_label')
+              .data(developers)
+              .transition()
+              .duration(event_time)
+              .attr('x', function(d, i) {
+                return bar_start_x+i*60+20;
+              });
+
+            // 棒グラフのソート
+            svg.select('.chart_area')
+              .selectAll('.bar')
+              .data(developers)
+              .transition()
+              .duration(event_time)
+              .attr('x', function(d, i) {
+                return bar_start_x+i*60;
+              });
+
+            // コミット数のソート
+            svg.select('.chart_area')
+              .selectAll('.bar_figure')
+              .data(developers)
+              .transition()
+              .duration(event_time)
+              .attr('x', function(d, i) {
+                return bar_start_x+i*60+20;
+              });
+
+          }
+          /* コミット数順 */
+          else if (in_order == 1) {
+            // 開発者ラベルのソート
+            svg.select('.chart_area')
+              .selectAll('.developer_label')
+              .data(developers)
+              .transition()
+              .duration(event_time)
+              .attr('x', function(d) {
+                for (var j=0; j<developers.length; j++) {
+                  if (d == sort_developers[j]) {
+                    return bar_start_x+(developers.length-1-j)*60+20;
+                  }
+                }
+              });
+
+            // 棒グラフのソート
+            svg.select('.chart_area')
+              .selectAll('.bar')
+              .data(developers)
+              .transition()
+              .duration(event_time)
+              .attr('x', function(d) {
+                for (var j=0; j<developers.length; j++) {
+                  if (d == sort_developers[j]) {
+                    return bar_start_x+(developers.length-1-j)*60;
+                  }
+                }
+              });
+
+            // コミット数のソート
+            svg.select('.chart_area')
+              .selectAll('.bar_figure')
+              .data(developers)
+              .transition()
+              .duration(event_time)
+              .attr('x', function(d) {
+                for (var j=0; j<developers.length; j++) {
+                  if (d == sort_developers[j]) {
+                    return bar_start_x+(developers.length-1-j)*60+20;
+                  }
+                }
+              });
+          }
         });
 
       // ソート順の表示

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -3,12 +3,12 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     var developer_name = ['その他', developer_name];
     var color = ['#b1d7e8', '#006ab3'];
 
-    // 取得データの一覧
+    /* 取得データの一覧 */
     // developers: 開発者のリスト
     // commit_count: 各開発者のコミット数
 
     // 取得データサンプル(連携後に消去)
-    var developers = ['DeveloperA', 'DeveloperB', 'DeveloperC', 'DeveloperD', '玄葉      条士郎'];
+    var developers = ['DeveloperA', 'DeveloperB', 'DeveloperC', 'DeveloperD', '玄葉 条士郎'];
     var commit_count = [38, 55, 103, 11, 82];
 
     // グラフの色
@@ -17,8 +17,8 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
 
     // SVG領域の設定
     var width = 960;
-    var height = 640;
-    var margin = {top: 50, right: 100, bottom: 0, left: 100};
+    var height = 540;
+    var margin = {top: 50, right: 100, bottom: 0, left: 150};
 
     // SVG領域の描画
     var svg = d3.select('body')
@@ -42,7 +42,8 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     /* 描画の実行 */
     /**************/
     drawBarChart();
-    sortBarChart(); 
+    sortBarChart();
+
     /******************/
     /* 棒グラフの描画 */
     /******************/
@@ -104,7 +105,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
           d3.select(this)
             .attr({
               'class': 'xaxis',
-              'd': line([[bar_start_x-20, bar_max_height-yScale(getCommitAvarage())], [bar_start_x-20+developers.length*60+20, bar_max_height-yScale(getCommitAvarage())]]),
+              'd': line([[bar_start_x-20, bar_max_height-yScale(getCommitAverage())], [bar_start_x-20+developers.length*60+20, bar_max_height-yScale(getCommitAverage())]]),
               'stroke': '#aaaaaa',
               'stroke-width': 1,
               'stroke-dasharray': 10,
@@ -114,6 +115,55 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
         .attr({
           'opacity': 1
         });
+
+      // 平均値の表示
+      svg.select('.chart_area')
+        .append('text')
+        .transition()
+        .duration(event_time)
+        .each('start', function() {
+          d3.select(this)
+            .attr({
+              'class': 'average_label',
+              'x': bar_start_x-20+developers.length*60+22,
+              'y': bar_max_height-yScale(getCommitAverage())-10,
+              'font-family': 'sans-serif',
+              'font-size': '15px',
+              'text-anchor': 'start',
+              'dominant-baseline': 'middle',
+              'fill': '#777777',
+              'opacity': 0
+            })
+            .text('平均');
+        })
+        .attr({
+          'opacity': 1
+        });
+
+      // 同上
+      svg.select('.chart_area')
+        .append('text')
+        .transition()
+        .duration(event_time)
+        .each('start', function() {
+          d3.select(this)
+            .attr({
+              'class': 'average_label',
+              'x': bar_start_x-20+developers.length*60+22,
+              'y': bar_max_height-yScale(getCommitAverage())+10,
+              'font-family': 'sans-serif',
+              'font-size': '15px',
+              'text-anchor': 'start',
+              'dominant-baseline': 'middle',
+              'fill': '#777777',
+              'opacity': 0
+            })
+            .text(getCommitAverage());
+        })
+        .attr({
+          'opacity': 1
+        });
+
 
       // 棒の表示 
       svg.select('.chart_area')
@@ -159,7 +209,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
             return bar_start_x+i*60+20;
           },
           'y': function(d, i) {
-            return bar_max_height-yScale(d)-15;
+            return bar_max_height-yScale(d)-10;
           },
           'font-family': 'sans-serif',
           'font-size': '15px',
@@ -247,9 +297,9 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
          });
     };
 
-    //
-    // 棒グラフのソート 
-    //
+    /********************/
+    /* 棒グラフのソート */ 
+    /********************/
     function sortBarChart() {
       var button_base_color = ['#4f81bd', '#c0504d'];
       var button_pale_color = ['#99b6d9', '#db9a98'];
@@ -286,12 +336,6 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
           }
         }
       }
-
-      // ソート結果の表示
-      console.log(commit_count);
-      console.log(developers);
-      console.log(sort_commit_count);
-      console.log(sort_developers);
 
       // ソートグループの作成
       svg.select('.chart_area')
@@ -498,7 +542,7 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     /*************/
     
     // コミット数の平均値
-    function getCommitAvarage() {
+    function getCommitAverage() {
       var avg = 0;
 
       for (var i=0; i<commit_count.length; i++) {

--- a/app/assets/javascripts/commit_counter_graph.js
+++ b/app/assets/javascripts/commit_counter_graph.js
@@ -18,21 +18,85 @@ var create_commit_graph = function(all_commit,own_commit,developer_name){
     // SVG領域の設定
     var width = 960;
     var height = 640;
-    var margin = {top: 0, right: 100, bottom: 0, left: 100};
+    var margin = {top: 50, right: 100, bottom: 0, left: 100};
 
     // SVG領域の描画
-    var svg = d3.select("body")
-          .append("svg")
-          .attr("class", "commit_counter_graph")
-          .attr("width", width)
-          .attr("height", height);
+    var svg = d3.select('body')
+          .append('svg')
+          .attr({
+            'class': 'commit_counter_graph',
+            'width': width,
+            'height': height
+          });
 
-    // SVG領域の確認
-    svg.append("text")
-      .text("Hello World")
-      .attr({
-        x: 150,
-        y: 150
-      })
-      .attr("font-size", "50px");
-}
+    /**************/
+    /* 描画の実行 */
+    /**************/
+    drawBarChart();
+    
+    /******************/
+    /* 棒グラフの描画 */
+    /******************/
+    function drawBarChart() {
+      // 棒の最大の高さ
+      var bar_max_height = 300;
+
+      // グラフエリアの設定
+      svg.append('g')
+        .attr({
+          'class': 'chart_area',
+          'transform': 'translate('+(margin.left)+', '+(margin.top)+')'
+        });
+
+      // グラフスケールの調整
+      var yScale = d3.scale.linear()
+                     .domain([0, d3.max(commit_count)])
+                     .range([0, bar_max_height])
+                     .nice();
+     
+     var line = d3.svg.line()
+                  .x(function(d) {
+                    return d[0];
+                  })
+                  .y(function(d) {
+                    return d[1];
+                  });
+
+      svg.select('.chart_area')
+        .append('path')
+        .transition()
+        .duration(1000)
+        .each('start', function() {
+          d3.select(this)
+            .attr({
+              'class': 'yaxis',
+              'd': line([[100,bar_max_height], [100, 0]]),
+              'stroke': '#aaaaaa',
+              'stroke-width': 1,
+              'opacity': 0
+            });
+        })
+        .attr({
+          'opacity': 1
+        });
+
+      svg.select('.chart_area')
+        .append('path')
+        .transition()
+        .duration(1000)
+        .each('start', function() {
+          d3.select(this)
+            .attr({
+              'class': 'xaxis',
+              'd': line([[100,bar_max_height], [100+developers.length*60, bar_max_height]]),
+              'stroke': '#aaaaaa',
+              'stroke-width': 1,
+              'opacity': 0
+            });
+        })
+        .attr({
+          'opacity': 1
+        });
+
+    };
+};

--- a/app/assets/javascripts/commit_counter_graph_old.js
+++ b/app/assets/javascripts/commit_counter_graph_old.js
@@ -1,0 +1,125 @@
+var create_commit_graph = function(all_commit,own_commit,developer_name){
+    var commit_count = [all_commit, own_commit];
+    var developer_name = ['その他', developer_name];
+    var color = ['#b1d7e8', '#006ab3'];
+
+    var topPadding = 50;
+    var leftPadding = 100;
+    var rightPadding = 20;
+    var w = 500+leftPadding+rightPadding;
+    var h = 400;
+
+    var barHeight = 100;
+
+    var xScale = d3.scale.linear()
+        .domain([0, all_commit])
+        .range([0, 500])
+        .nice();
+
+    var xAxis = d3.svg.axis()
+        .scale(xScale)
+        .orient("bottom");
+
+    var svg = d3.select("body")
+        .append("svg")
+        .attr("width", w)
+        .attr("height", h);
+
+// x軸の表示
+    svg.append("g")
+        .attr({
+            class: "axis",
+            transform: "translate("+leftPadding+", 150)"
+        })
+        .call(xAxis);
+
+// 棒グラフの描画
+    svg.selectAll("rect")
+        .data(commit_count)
+        .enter()
+        .append("rect")
+        .attr("fill", function(d, i) {
+            return color[i];
+        })
+        .transition()
+        .duration(2000)
+        .each("start", function() {
+            d3.select(this).attr({
+                width: 0
+            })
+        })
+        .attr("x", leftPadding)
+        .attr("y", 40)
+        .attr("width", function(d) {
+            return xScale(d);
+        })
+        .attr("height", barHeight);
+
+// コミット数の表示
+    svg.selectAll("commit_count")
+        .data(commit_count)
+        .enter()
+        .append("text")
+        .attr("opacity", 0.0)
+        .text(function(d, i) {
+            if (i == 0) {
+                return d - commit_count[i+1];
+            } else {
+                return d;
+            }
+        })
+        .attr("x", function(d, i) {
+            if (i == 0) {
+                return leftPadding + xScale(commit_count[i+1]) + xScale(d - commit_count[i+1])/2;
+            } else {
+                return leftPadding + xScale(d)/2;
+            }
+        })
+        .attr("y", function(d) {
+            return 30 + barHeight/2;
+        })
+        .attr("text-anchor", "middle")
+        .attr("font-family", "sans-serif")
+        .attr("font-size", "20px")
+        .attr("fill", "white")
+        .transition()
+        .each("end", function() {
+            d3.select(this)
+                .transition()
+                .duration(2000)
+                .attr("opacity", 1.0)
+        });
+
+// 開発者名の表示
+    svg.selectAll("developer_name")
+        .data(developer_name)
+        .enter()
+        .append("text")
+        .attr("opacity", 0.0)
+        .text(function(d, i) {
+            return d;
+        })
+        .attr("x", function(d, i) {
+            if (i == 0) {
+                return leftPadding + xScale(commit_count[i+1]) + xScale(commit_count[i] - commit_count[i+1])/2;
+            } else {
+                return leftPadding + xScale(commit_count[i])/2;
+            }
+        })
+        .attr("y", function(d) {
+            return 30;
+        })
+        .attr("text-anchor", "middle")
+        .attr("font-family", "sans-serif")
+        .attr("font-size", "15px")
+        .attr("fill", "black")
+        .transition()
+        .each("end", function() {
+            d3.select(this)
+                .transition()
+                .duration(2000)
+                .attr("opacity", 1.0)
+        });
+}
+
+


### PR DESCRIPTION
## Overview
#231 のViewの実装

## Review
メトリクス一覧の閲覧ページに移動してプロジェクトを選択すると、しばらくしてから以下のようなグラフが現れます。ソート機能しかありませんが、挙動がおかしくならないか確認してください。
なお、Firefoxの場合は開発者名が横になってしまいますが、仕様です。
<img width="493" alt="2015-10-29 19 39 36" src="https://cloud.githubusercontent.com/assets/6702920/10816271/de76628c-7e74-11e5-8a2f-d8852bda88ec.png">

実データとの連携は別のブランチでやります。
また、'commit_counter_graph_old.js'は利用していませんが、 **不測の事態** に対応するために置いてあるので、今は削除しないでください。

その他、指摘があればコメントください。