### PR TITLE
[IR] グラフの説明文部分の追加 7.0h

### DIFF
--- a/app/assets/javascripts/own/commit_counter_graph.js
+++ b/app/assets/javascripts/own/commit_counter_graph.js
@@ -68,7 +68,7 @@ var create_commit_graph = function(developers,commit_count){
               'fill': '#777777',
               'opacity': 0
             })
-            .text('コミット数');
+            .text('コミット数(回)');
         })
         .attr({
           'opacity': 1

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -71,7 +71,7 @@ Vibi.load = function(e) {
                 'id': 'commit_explanation',
                 'x': 540,
                 'y': 460,
-                'font-size': '20px',
+                    'font-size': '15px',
                 'text-anchor': 'middle'
             })
             .text('チーム内の開発者のコミット回数を表すグラフ（単位：回）');
@@ -87,23 +87,34 @@ Vibi.load = function(e) {
                 'text-anchor': 'middle'
             })
             .text('開発者全員効率一覧');
-        //効率メトリクス説明文の再作成
+        //効率メトリクス説明文1の再作成
         d3.select("#productivity_graph")
             .append('text')
             .attr({
-                'id': 'productivity_explanation',
+                'id': 'productivity_explanation1',
                 'x': 540,
                 'y': 60,
-                'font-size': '20px',
+                'font-size': '15px',
                 'text-anchor': 'middle'
             })
-            .text('開発者効率円グラフ');
+            .text('円の半径で、実績作業時間と予定作業時間の関係を示す。円のある部分を選択すると、そのトラッカーに対する開発者全員の生産性が表示できる。');
 
+        //効率メトリクス説明文2の再作成
+        d3.select("#productivity_graph")
+            .append('text')
+            .attr({
+                'id': 'productivity_explanation2',
+                'x': 540,
+                'y': 80,
+                'font-size': '15px',
+                'text-anchor': 'middle'
+            })
+            .text('「return」ボタンを押すと、円グラフリストに戻る。');
         //グラフの生成
         commitAjax();
         costAjax();
-        //commentAjax();
-        //skillAjax();
+        commentAjax();
+        skillAjax();
       });
     }
   }

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -76,28 +76,17 @@ Vibi.load = function(e) {
             })
             .text('チーム内の開発者のコミット回数を表すグラフ（単位：回）');
 
-        //効率メトリクスタイトルの再作成
-        d3.select("#productivity_graph")
-            .append('text')
-            .attr({
-                'id': 'productivity_title',
-                'x': 540,
-                'y': 30,
-                'font-size': '20px',
-                'text-anchor': 'middle'
-            })
-            .text('開発者全員効率一覧');
         //効率メトリクス説明文1の再作成
         d3.select("#productivity_graph")
             .append('text')
             .attr({
                 'id': 'productivity_explanation1',
                 'x': 540,
-                'y': 60,
+                'y': 40,
                 'font-size': '15px',
                 'text-anchor': 'middle'
             })
-            .text('円の半径で、実績作業時間と予定作業時間の関係を示す。円のある部分を選択すると、そのトラッカーに対する開発者全員の生産性が表示できる。');
+            .text('見積り作業時間/実績作業時間で各開発者の効率を算出している。');
 
         //効率メトリクス説明文2の再作成
         d3.select("#productivity_graph")
@@ -105,11 +94,11 @@ Vibi.load = function(e) {
             .attr({
                 'id': 'productivity_explanation2',
                 'x': 540,
-                'y': 80,
+                'y': 60,
                 'font-size': '15px',
                 'text-anchor': 'middle'
             })
-            .text('「return」ボタンを押すと、円グラフリストに戻る。');
+            .text('棒グラフの棒をクリックすると、該当開発者の円グラフに遷移する。「return」ボタンを押すと、円グラフリストに戻る。');
         //グラフの生成
         commitAjax();
         costAjax();

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -70,7 +70,7 @@ Vibi.load = function(e) {
             .attr({
                 'id': 'commit_explanation',
                 'x': 540,
-                'y': 460,
+                'y': 30,
                     'font-size': '15px',
                 'text-anchor': 'middle'
             })

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -82,11 +82,11 @@ Vibi.load = function(e) {
             .attr({
                 'id': 'productivity_explanation1',
                 'x': 540,
-                'y': 40,
+                'y': 30,
                 'font-size': '15px',
                 'text-anchor': 'middle'
             })
-            .text('見積り作業時間/実績作業時間で各開発者の効率を算出している。');
+            .text('このグラフは作業効率を表すグラフである。作業効率は以下の数式で計算している：見積り作業時間/実績作業時間');
 
         //効率メトリクス説明文2の再作成
         d3.select("#productivity_graph")
@@ -94,11 +94,11 @@ Vibi.load = function(e) {
             .attr({
                 'id': 'productivity_explanation2',
                 'x': 540,
-                'y': 60,
+                'y': 50,
                 'font-size': '15px',
                 'text-anchor': 'middle'
             })
-            .text('棒グラフの棒をクリックすると、該当開発者の円グラフに遷移する。「return」ボタンを押すと、円グラフリストに戻る。');
+            .text('グラフの中の元素をクリックし、画面が遷移できる。');
         //グラフの生成
         commitAjax();
         costAjax();

--- a/app/assets/javascripts/own/vibi.js
+++ b/app/assets/javascripts/own/vibi.js
@@ -64,11 +64,46 @@ Vibi.load = function(e) {
             'opacity':0.5
           });
 
+        //コミットメトリクス説明文の再作成
+        d3.select("#commit_counter_graph")
+            .append('text')
+            .attr({
+                'id': 'commit_explanation',
+                'x': 540,
+                'y': 460,
+                'font-size': '20px',
+                'text-anchor': 'middle'
+            })
+            .text('チーム内の開発者のコミット回数を表すグラフ（単位：回）');
+
+        //効率メトリクスタイトルの再作成
+        d3.select("#productivity_graph")
+            .append('text')
+            .attr({
+                'id': 'productivity_title',
+                'x': 540,
+                'y': 30,
+                'font-size': '20px',
+                'text-anchor': 'middle'
+            })
+            .text('開発者全員効率一覧');
+        //効率メトリクス説明文の再作成
+        d3.select("#productivity_graph")
+            .append('text')
+            .attr({
+                'id': 'productivity_explanation',
+                'x': 540,
+                'y': 60,
+                'font-size': '20px',
+                'text-anchor': 'middle'
+            })
+            .text('開発者効率円グラフ');
+
         //グラフの生成
         commitAjax();
         costAjax();
-        commentAjax();
-        skillAjax();
+        //commentAjax();
+        //skillAjax();
       });
     }
   }

--- a/app/assets/stylesheets/vibi.css
+++ b/app/assets/stylesheets/vibi.css
@@ -72,8 +72,20 @@ body {
     -moz-opacity:0.5;opacity: 0.5;
 }
 
-#productivity_explanation {display:none; text-decoration:none}
-#productivity_graph:hover #productivity_explanation{
+#productivity_explanation1 {display:none; text-decoration:none}
+#productivity_explanation2 {display:none; text-decoration:none}
+#productivity_graph:hover #productivity_explanation1{
+    display:block;
+    position:absolute;
+    bottom:0;
+    left:0;
+    color:#FFF;
+    width:554px;
+    background:#000;
+    filter:alpha(opacity=60);
+    -moz-opacity:0.5;opacity: 0.5;
+}
+#productivity_graph:hover #productivity_explanation2{
     display:block;
     position:absolute;
     bottom:0;

--- a/app/assets/stylesheets/vibi.css
+++ b/app/assets/stylesheets/vibi.css
@@ -58,3 +58,29 @@ body {
   background-repeat: no-repeat;
   margin: 0 auto;
 }
+
+#commit_explanation {display:none; text-decoration:none}
+#commit_counter_graph:hover #commit_explanation{
+    display:block;
+    position:absolute;
+    bottom:0;
+    left:0;
+    color:#FFF;
+    width:554px;
+    background:#000;
+    filter:alpha(opacity=60);
+    -moz-opacity:0.5;opacity: 0.5;
+}
+
+#productivity_explanation {display:none; text-decoration:none}
+#productivity_graph:hover #productivity_explanation{
+    display:block;
+    position:absolute;
+    bottom:0;
+    left:0;
+    color:#FFF;
+    width:554px;
+    background:#000;
+    filter:alpha(opacity=60);
+    -moz-opacity:0.5;opacity: 0.5;
+}

--- a/app/views/portfolio/index.html.erb
+++ b/app/views/portfolio/index.html.erb
@@ -6,10 +6,13 @@
 <svg id="commit_counter_graph" class="commit_counter_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
   <text x="540" y="240" font-size="20px" text-anchor="middle">コミットグラフ</text>
+  <text id="commit_explanation" x="540" y="460" font-size="20px" text-anchor="middle">チーム内の開発者のコミット回数を表すグラフ（単位：回）</text>
 </svg>
 <svg id="productivity_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
   <text x="540" y="240" font-size="20px" text-anchor="middle">生産性グラフ</text>
+  <text id="productivity_title" x="540" y="30" font-size="20px" text-anchor="middle">開発者全員効率一覧</text>
+  <text id="productivity_explanation" x="540" y="60" font-size="20px" text-anchor="middle">開発者効率円グラフ</text>
 </svg>
 <svg id="comments_counter_graph" class="comment_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />

--- a/app/views/portfolio/index.html.erb
+++ b/app/views/portfolio/index.html.erb
@@ -6,13 +6,14 @@
 <svg id="commit_counter_graph" class="commit_counter_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
   <text x="540" y="240" font-size="20px" text-anchor="middle">コミットグラフ</text>
-  <text id="commit_explanation" x="540" y="460" font-size="20px" text-anchor="middle">チーム内の開発者のコミット回数を表すグラフ（単位：回）</text>
+  <text id="commit_explanation" x="540" y="460" font-size="15px" text-anchor="middle">チーム内の開発者のコミット回数を表すグラフ（単位：回）</text>
 </svg>
 <svg id="productivity_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
   <text x="540" y="240" font-size="20px" text-anchor="middle">生産性グラフ</text>
   <text id="productivity_title" x="540" y="30" font-size="20px" text-anchor="middle">開発者全員効率一覧</text>
-  <text id="productivity_explanation" x="540" y="60" font-size="20px" text-anchor="middle">開発者効率円グラフ</text>
+  <text id="productivity_explanation1" x="540" y="60" font-size="15px" text-anchor="middle">円の半径で、実績作業時間と予定作業時間の関係を示す。円のある部分を選択すると、そのトラッカーに対する開発者全員の生産性が表示できる。</text>
+  <text id="productivity_explanation2" x="540" y="80" font-size="15px" text-anchor="middle">「return」ボタンを押すと、円グラフリストに戻る。</text>
 </svg>
 <svg id="comments_counter_graph" class="comment_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />

--- a/app/views/portfolio/index.html.erb
+++ b/app/views/portfolio/index.html.erb
@@ -11,8 +11,8 @@
 <svg id="productivity_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
   <text x="540" y="240" font-size="20px" text-anchor="middle">効率グラフ</text>
-  <text id="productivity_explanation1" x="540" y="40" font-size="15px" text-anchor="middle">見積り作業時間/実績作業時間で各開発者の効率を算出している。</text>
-  <text id="productivity_explanation2" x="540" y="60" font-size="15px" text-anchor="middle">棒グラフの棒をクリックすると、該当開発者の円グラフに遷移する。「return」ボタンを押すと、円グラフリストに戻る。</text>
+  <text id="productivity_explanation1" x="540" y="30" font-size="15px" text-anchor="middle">このグラフは作業効率を表すグラフである。作業効率は以下の数式で計算している：見積り作業時間/実績作業時間</text>
+  <text id="productivity_explanation2" x="540" y="50" font-size="15px" text-anchor="middle">グラフの中の元素をクリックし、画面が遷移できる。</text>
 </svg>
 <svg id="comments_counter_graph" class="comment_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />

--- a/app/views/portfolio/index.html.erb
+++ b/app/views/portfolio/index.html.erb
@@ -6,7 +6,7 @@
 <svg id="commit_counter_graph" class="commit_counter_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
   <text x="540" y="240" font-size="20px" text-anchor="middle">コミットグラフ</text>
-  <text id="commit_explanation" x="540" y="460" font-size="15px" text-anchor="middle">チーム内の開発者のコミット回数を表すグラフ（単位：回）</text>
+  <text id="commit_explanation" x="540" y="30" font-size="15px" text-anchor="middle">チーム内の開発者のコミット回数を表すグラフ（単位：回）</text>
 </svg>
 <svg id="productivity_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />

--- a/app/views/portfolio/index.html.erb
+++ b/app/views/portfolio/index.html.erb
@@ -10,10 +10,9 @@
 </svg>
 <svg id="productivity_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />
-  <text x="540" y="240" font-size="20px" text-anchor="middle">生産性グラフ</text>
-  <text id="productivity_title" x="540" y="30" font-size="20px" text-anchor="middle">開発者全員効率一覧</text>
-  <text id="productivity_explanation1" x="540" y="60" font-size="15px" text-anchor="middle">円の半径で、実績作業時間と予定作業時間の関係を示す。円のある部分を選択すると、そのトラッカーに対する開発者全員の生産性が表示できる。</text>
-  <text id="productivity_explanation2" x="540" y="80" font-size="15px" text-anchor="middle">「return」ボタンを押すと、円グラフリストに戻る。</text>
+  <text x="540" y="240" font-size="20px" text-anchor="middle">効率グラフ</text>
+  <text id="productivity_explanation1" x="540" y="40" font-size="15px" text-anchor="middle">見積り作業時間/実績作業時間で各開発者の効率を算出している。</text>
+  <text id="productivity_explanation2" x="540" y="60" font-size="15px" text-anchor="middle">棒グラフの棒をクリックすると、該当開発者の円グラフに遷移する。「return」ボタンを押すと、円グラフリストに戻る。</text>
 </svg>
 <svg id="comments_counter_graph" class="comment_graph" width="1080" height="480">
   <rect class="frame" x="0" y="0" width="1080" height="480" style="fill:white;stroke:gray;stroke-width:5;opacity:0.5" />


### PR DESCRIPTION
### Done
- 説明文の入れる（ちょっとscreenshotできないけど）
  現時点もしmouseがsvgの空間に入ると自動的にsvgの下、あるいは上の部分に説明文が表示する
- 説明文内容：
  - コミットグラフ：svgの下に「チーム内の開発者のコミット回数を表すグラフ（単位：回）」説明文が表示される
  - 効率グラフ ：
    - svgの上にタイトル「開発者全員効率一覧」が表示される
    - svgの上に「このグラフは作業効率を表すグラフである。作業効率は以下の数式で計算している：見積り作業時間/実績作業時間。グラフの中の元素をクリックし、画面が遷移できる。」説明文が表示される
### Review
- zouyimin/svg-description
- メトリクスを見る画面に移動して、プロジェクトを選択しない状態でmouseが一番目と二番目のsvgに入って、文字が表示できるかどうか
- プロジェクトを選択して、全部実行終わってからまたmouseが一番目と二番目のsvgに入って、文字が表示できるかどうか
